### PR TITLE
fix(model): Add an option to hide the color-by geometry

### DIFF
--- a/extras-requirements.txt
+++ b/extras-requirements.txt
@@ -1,3 +1,3 @@
 honeybee-energy>=1.95.19
 honeybee-radiance>=1.64.105
-ladybug-vtk>=0.10.0
+ladybug-vtk>=0.11.1

--- a/honeybee_display/cli/__init__.py
+++ b/honeybee_display/cli/__init__.py
@@ -43,6 +43,12 @@ def display():
     'Also, merging the geometry into a single mesh means interfaces cannot support '
     'the selection of individual Face3D geometries.', default=True, show_default=True)
 @click.option(
+    '--show-color-by/--hide-color-by', ' /-hcb', help='Flag to note whether the '
+    'color-by geometry should be hidden or shown by default. Hiding the color-by '
+    'geometry is useful when the primary purpose of the visualization is to display '
+    'grid-data or room/face attributes but it is still desirable to have the option '
+    'to turn on the geometry.', default=True, show_default=True)
+@click.option(
     '--room-attr', '-r', help='An optional text string of an attribute that the Model '
     'Rooms have, which will be used to construct a visualization of this attribute '
     'in the resulting VisualizationSet. This can also be a list of attribute strings '
@@ -97,7 +103,8 @@ def display():
     'the config object. By default, it will be printed out to stdout',
     type=click.File('w'), default='-', show_default=True)
 def model_to_vis_set(
-        model_file, color_by, wireframe, mesh, room_attr, face_attr, color_attr,
+        model_file, color_by, wireframe, mesh, show_color_by,
+        room_attr, face_attr, color_attr,
         grid_data, grid_display_mode, output_format, output_file):
     """Get a JSON object with all configuration information"""
     try:
@@ -105,9 +112,10 @@ def model_to_vis_set(
         room_attr = None if len(room_attr) == 0 or room_attr[0] == '' else room_attr
         face_attr = None if len(face_attr) == 0 or face_attr[0] == '' else face_attr
         text_labels = not color_attr
+        hide_color_by = not show_color_by
         vis_set = model_obj.to_vis_set(
             color_by=color_by, include_wireframe=wireframe, use_mesh=mesh,
-            room_attr=room_attr, face_attr=face_attr,
+            hide_color_by=hide_color_by, room_attr=room_attr, face_attr=face_attr,
             room_text_labels=text_labels, face_text_labels=text_labels,
             grid_data_path=grid_data, grid_display_mode=grid_display_mode)
         output_format = output_format.lower()

--- a/honeybee_display/model.py
+++ b/honeybee_display/model.py
@@ -41,7 +41,8 @@ BC_COLORS = {
 
 def model_to_vis_set(
         model, color_by='type', include_wireframe=True, use_mesh=True,
-        room_attr=None, face_attr=None, room_text_labels=False, face_text_labels=False,
+        hide_color_by=False, room_attr=None, face_attr=None,
+        room_text_labels=False, face_text_labels=False,
         room_legend_par=None, face_legend_par=None,
         grid_data_path=None, grid_display_mode='Surface'):
     """Translate a Honeybee Model to a VisualizationSet.
@@ -69,6 +70,11 @@ def model_to_vis_set(
             (meaning that their wireframe in certain platforms might not appear ideal)
             and they cannot support the selection of individual Face3D geometries
             in the resulting visualization. (Default: True).
+        hide_color_by: Boolean to note whether the color_by geometry should be
+            hidden or shown by default. Hiding the color-by geometry is useful
+            when the primary purpose of the visualization is to display grid_data
+            or room/face attributes but it is still desirable to have the option
+            to turn on the geometry.
         room_attr: An optional text string of an attribute that the Model Rooms have,
             which will be used to construct a visualization of this attribute in the
             resulting VisualizationSet. This can also be a list of attribute strings and
@@ -229,6 +235,8 @@ def model_to_vis_set(
                 for geo in geometries:
                     dis_geos.append(DisplayFace3D(geo, col))
             con_geo = ContextGeometry(geo_id.replace(' ', '_'), dis_geos)
+            if hide_color_by:
+                con_geo.hidden = True
             con_geo.display_name = geo_id
             geo_objs.append(con_geo)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ladybug-display>=0.6.7
-honeybee-core>=1.54.6
+ladybug-display>=0.6.10
+honeybee-core>=1.54.10


### PR DESCRIPTION
This will be useful for visualizations where the first thing we want the user to see is an AnalysisGeometry in relation to the model Wireframe.