### PR TITLE
Refactor face_attr and room_attr inputs

### DIFF
--- a/honeybee_display/attr.py
+++ b/honeybee_display/attr.py
@@ -1,4 +1,8 @@
 """Display attribute objects for creating visualization sets."""
+from honeybee.facetype import Wall, RoofCeiling, Floor, AirBoundary
+from honeybee.aperture import Aperture
+from honeybee.shade import Shade
+from honeybee.boundarycondition import Outdoors, Surface, Ground
 
 
 class RoomAttribute(object):
@@ -14,13 +18,10 @@ class RoomAttribute(object):
             ContextGeometry layer if color is True). Attributes input here can have '.'
             that separates the nested attributes from one another. For example,
             'properties.energy.construction' or 'user_data.tag'
-
         color: A boolean to note whether the input room_attr should be expressed as a
             colored AnalysisGeometry. (Default: True)
-
         text: A boolean to note whether the input room_attr should be expressed as a
             a ContextGeometry as text labels. (Default: False)
-
         legend_par:An optional LegendParameter object to customize the display of the
             attribute. For text attribute only the text_height and font will be used to
             customize the text.
@@ -34,6 +35,46 @@ class RoomAttribute(object):
         self.color = color
         self.text = text
         self.legend_par = legend_par
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        self._name = value
+
+    @property
+    def attr(self):
+        return self._attr
+
+    @attr.setter
+    def attr(self, value):
+        self._attr = value
+
+    @property
+    def color(self):
+        return self._color
+
+    @color.setter
+    def color(self, value):
+        self._color = value
+
+    @property
+    def text(self):
+        return self._text
+
+    @text.setter
+    def text(self, value):
+        self._text = value
+
+    @property
+    def legend_par(self):
+        return self._legend_par
+
+    @legend_par.setter
+    def legend_par(self, value):
+        self._legend_par = value
 
 
 class FaceAttribute(RoomAttribute):
@@ -71,8 +112,45 @@ class FaceAttribute(RoomAttribute):
             * Aperture
             * Shade
 
+        boundary_conditions: List of face boundary conditions to be included in the
+            visualization set. This condition will be applied as a secondary check for
+            the face_types that are set using the face_types argument. Valid values 
+            are:
+
+            * Outdoors
+            * Surface
+            * Ground
+
     """
 
-    def __init__(self, name, attr, color=True, text=False, legend_par=None, face_types=None):
+    def __init__(
+        self, name, attr, color=True, text=False, legend_par=None, face_types=None,
+            boundary_conditions=None):
         super().__init__(name, attr, color, text, legend_par)
         self.face_types = face_types
+        self.boundary_conditions = boundary_conditions
+
+    @property
+    def face_types(self):
+        return self._face_types
+
+    @face_types.setter
+    def face_types(self, types):
+        types = types or []
+        for type in types:
+            assert type in (Wall, RoofCeiling, Floor, AirBoundary, Aperture, Shade), \
+                f'Invalid face type: {type}'
+        self._face_types = types
+
+    @property
+    def boundary_conditions(self):
+        return self._boundary_conditions
+
+    @boundary_conditions.setter
+    def boundary_conditions(self, bcs):
+        bcs = bcs or []
+        for bc in bcs:
+            assert bc in (Outdoors, Surface, Ground), \
+                f'Invalid face boundary condition: {bc}. Valid values are Outdoors, ' \
+                'Surface and Ground.'
+        self._boundary_conditions = bcs

--- a/honeybee_display/attr.py
+++ b/honeybee_display/attr.py
@@ -1,0 +1,78 @@
+"""Display attribute objects for creating visualization sets."""
+
+
+class RoomAttribute(object):
+    """A Room attribute object.
+
+    Args:
+        name: A name for this Room Attribute.
+        attr: A list of text strings of attributes that the Model Rooms have, which will
+            be used to construct a visualization of this attribute in the resulting
+            VisualizationSet. This can also be a list of attribute strings and a
+            separate VisualizationData will be added to the AnalysisGeometry that
+            represents the attribute in the resulting VisualizationSet (or a separate
+            ContextGeometry layer if color is True). Attributes input here can have '.'
+            that separates the nested attributes from one another. For example,
+            'properties.energy.construction' or 'user_data.tag'
+
+        color: A boolean to note whether the input room_attr should be expressed as a
+            colored AnalysisGeometry. (Default: True)
+
+        text: A boolean to note whether the input room_attr should be expressed as a
+            a ContextGeometry as text labels. (Default: False)
+
+        legend_par:An optional LegendParameter object to customize the display of the
+            attribute. For text attribute only the text_height and font will be used to
+            customize the text.
+    """
+
+    def __init__(
+        self, name, attr, color=True, text=False, legend_par=None
+            ):
+        self.name = name
+        self.attr = attr
+        self.color = color
+        self.text = text
+        self.legend_par = legend_par
+
+
+class FaceAttribute(RoomAttribute):
+    """A Face attribute object.
+
+    Args:
+        name: A name for this Face Attribute.
+        attr: A list of text strings of attributes the Model Faces have, which will
+            be used to construct a visualization of this attribute in the resulting
+            VisualizationSet. This can also be a list of attribute strings and a
+            separate VisualizationData will be added to the AnalysisGeometry that
+            represents the attribute in the resulting VisualizationSet (or a separate
+            ContextGeometry layer if color is True). Attributes input here can have '.'
+            that separates the nested attributes from one another. For example,
+            'properties.energy.construction' or 'user_data.tag'
+
+        color: A boolean to note whether the input room_attr should be expressed as a
+            colored AnalysisGeometry. (Default: True)
+
+        text: A boolean to note whether the input room_attr should be expressed as a
+            a ContextGeometry as text labels. (Default: False)
+
+        legend_par:An optional LegendParameter object to customize the display of the
+            attribute. For text attribute only the text_height and font will be used to
+            customize the text.
+
+        face_types: List of face types to be included in the visualization set. By
+            default all the faces will be exported to visualization set. Valid values
+            are:
+
+            * Wall
+            * RoofCeiling
+            * Floor
+            * AirBoundary
+            * Aperture
+            * Shade
+
+    """
+
+    def __init__(self, name, attr, color=True, text=False, legend_par=None, face_types=None):
+        super().__init__(name, attr, color, text, legend_par)
+        self.face_types = face_types

--- a/honeybee_display/attr.py
+++ b/honeybee_display/attr.py
@@ -10,7 +10,7 @@ class RoomAttribute(object):
 
     Args:
         name: A name for this Room Attribute.
-        attr: A list of text strings of attributes that the Model Rooms have, which will
+        attrs: A list of text strings of attributes that the Model Rooms have, which will
             be used to construct a visualization of this attribute in the resulting
             VisualizationSet. This can also be a list of attribute strings and a
             separate VisualizationData will be added to the AnalysisGeometry that
@@ -28,10 +28,10 @@ class RoomAttribute(object):
     """
 
     def __init__(
-        self, name, attr, color=True, text=False, legend_par=None
+        self, name, attrs, color=True, text=False, legend_par=None
             ):
         self.name = name
-        self.attr = attr
+        self.attrs = attrs
         self.color = color
         self.text = text
         self.legend_par = legend_par
@@ -45,12 +45,12 @@ class RoomAttribute(object):
         self._name = value
 
     @property
-    def attr(self):
-        return self._attr
+    def attrs(self):
+        return self._attrs
 
-    @attr.setter
-    def attr(self, value):
-        self._attr = value
+    @attrs.setter
+    def attrs(self, value):
+        self._attrs = value
 
     @property
     def color(self):
@@ -82,7 +82,7 @@ class FaceAttribute(RoomAttribute):
 
     Args:
         name: A name for this Face Attribute.
-        attr: A list of text strings of attributes the Model Faces have, which will
+        attrs: A list of text strings of attributes the Model Faces have, which will
             be used to construct a visualization of this attribute in the resulting
             VisualizationSet. This can also be a list of attribute strings and a
             separate VisualizationData will be added to the AnalysisGeometry that
@@ -124,9 +124,9 @@ class FaceAttribute(RoomAttribute):
     """
 
     def __init__(
-        self, name, attr, color=True, text=False, legend_par=None, face_types=None,
+        self, name, attrs, color=True, text=False, legend_par=None, face_types=None,
             boundary_conditions=None):
-        super().__init__(name, attr, color, text, legend_par)
+        super().__init__(name, attrs, color, text, legend_par)
         self.face_types = face_types
         self.boundary_conditions = boundary_conditions
 

--- a/honeybee_display/cli/__init__.py
+++ b/honeybee_display/cli/__init__.py
@@ -9,6 +9,8 @@ import pickle
 from honeybee.model import Model
 from honeybee.cli import main
 
+from honeybee_display.attr import FaceAttribute, RoomAttribute
+
 _logger = logging.getLogger(__name__)
 
 
@@ -136,16 +138,27 @@ def model_to_vis_set(
     """
     try:
         model_obj = Model.from_file(model_file)
-        room_attr = None if len(room_attr) == 0 or room_attr[0] == '' else room_attr
-        face_attr = None if len(face_attr) == 0 or face_attr[0] == '' else face_attr
+        room_attrs = [] if len(room_attr) == 0 or room_attr[0] == '' else room_attr
+        face_attrs = [] if len(face_attr) == 0 or face_attr[0] == '' else face_attr
         text_labels = not color_attr
         hide_color_by = not show_color_by
+
+        face_attributes = []
+        for fa in face_attrs:
+            faa = FaceAttribute(name=fa, attrs=[fa], color=color_attr, text=text_labels)
+            face_attributes.append(faa)
+
+        room_attributes = []
+        for ra in room_attrs:
+            raa = RoomAttribute(name=ra, attrs=[ra], color=color_attr, text=text_labels)
+            room_attributes.append(raa)
+
         vis_set = model_obj.to_vis_set(
             color_by=color_by, include_wireframe=wireframe, use_mesh=mesh,
-            hide_color_by=hide_color_by, room_attr=room_attr, face_attr=face_attr,
-            room_text_labels=text_labels, face_text_labels=text_labels,
-            grid_display_mode=grid_display_mode, hide_grid=hide_grid,
-            grid_data_path=grid_data, grid_data_display_mode=grid_data_display_mode,
+            hide_color_by=hide_color_by, room_attrs=room_attributes,
+            face_attrs=face_attributes, grid_display_mode=grid_display_mode,
+            hide_grid=hide_grid, grid_data_path=grid_data,
+            grid_data_display_mode=grid_data_display_mode,
             active_grid_data=active_grid_data)
         output_format = output_format.lower()
         if output_format in ('vsf', 'json'):

--- a/honeybee_display/colorobj.py
+++ b/honeybee_display/colorobj.py
@@ -153,11 +153,12 @@ def color_face_to_vis_set(
     # use text labels if requested
     if text_labels:
         # set up default variables
-        max_txt_h, p_tol = float('inf'), 0.01
+        max_txt_h, p_tol, offset_from_base = float('inf'), 0.01, 0.005
         if units is not None:
             fac_to_m = conversion_factor_to_meters(units)
             max_txt_h = 0.25 / fac_to_m
             p_tol = parse_distance_string('0.01m', units)
+            offset_from_base = parse_distance_string('0.005m', units)
         label_text = []
         txt_height = None if color_face.legend_parameters.is_text_height_default \
             else color_face.legend_parameters.text_height
@@ -167,6 +168,7 @@ def color_face_to_vis_set(
             if face_prop != 'N/A':
                 cent_pt = f_geo.center if f_geo.is_convex else \
                     f_geo.pole_of_inaccessibility(p_tol)
+                cent_pt = cent_pt.move(f_geo.normal * offset_from_base)
                 base_plane = Plane(f_geo.normal, cent_pt)
                 if base_plane.y.z < 0:  # base plane pointing downwards; rotate it
                     base_plane = base_plane.rotate(base_plane.n, math.pi, base_plane.o)

--- a/honeybee_display/model.py
+++ b/honeybee_display/model.py
@@ -43,7 +43,7 @@ BC_COLORS = {
 
 def model_to_vis_set(
         model, color_by='type', include_wireframe=True, use_mesh=True,
-        hide_color_by=False, room_attr=None, face_attr=None,
+        hide_color_by=False, room_attrs=None, face_attrs=None,
         grid_display_mode='Default', hide_grid=True,
         grid_data_path=None, grid_data_display_mode='Surface', active_grid_data=None):
     """Translate a Honeybee Model to a VisualizationSet.
@@ -54,7 +54,7 @@ def model_to_vis_set(
             If none, only a wireframe of the Model will be generated, assuming
             include_wireframe is True. This is useful when the primary purpose of
             the visualization is to display results in relation to the Model
-            geometry or display some room_attr or face_attr as an AnalysisGeometry
+            geometry or display some room_attrs or face_attrs as an AnalysisGeometry
             or Text labels. (Default: type). Choose from the following:
 
             * type
@@ -74,8 +74,8 @@ def model_to_vis_set(
             when the primary purpose of the visualization is to display grid_data
             or room/face attributes but it is still desirable to have the option
             to turn on the geometry.
-        room_attr: An optional list of room attribute objects.
-        face_attr: An optional list of face attribute objects.
+        room_attrs: An optional list of room attribute objects.
+        face_attrs: An optional list of face attribute objects.
         grid_display_mode: Text that dictates how the ContextGeometry for Model
             SensorGrids should display in the resulting visualization. The Default
             option will draw sensor points whenever there is no grid_data_path and
@@ -234,9 +234,9 @@ def model_to_vis_set(
             geo_objs.append(con_geo)
 
     # add room attributes to the VisualizationSet if requested
-    if room_attr and len(model.rooms) != 0:
-        for rm_attr in room_attr:
-            attrs = rm_attr.attr
+    if room_attrs and len(model.rooms) != 0:
+        for rm_attr in room_attrs:
+            attrs = rm_attr.attrs
             if rm_attr.text:
                 units, tol = model.units, model.tolerance
                 for r_attr in attrs:
@@ -255,7 +255,7 @@ def model_to_vis_set(
                 geo_objs.append(geo_obj)
 
     # add face attributes to the VisualizationSet if requested
-    if face_attr is not None and len(face_attr) != 0:
+    if face_attrs is not None and len(face_attrs) != 0:
         faces = []
         for room in model.rooms:
             faces.extend(room.faces)
@@ -266,7 +266,7 @@ def model_to_vis_set(
         faces.extend(model.orphaned_doors)
         faces.extend(model.orphaned_shades)
         if len(faces) != 0:
-            for ff_attr in face_attr:
+            for ff_attr in face_attrs:
                 if ff_attr.face_types:
                     face_attr_types = tuple(ff_attr.face_types)
                     f_faces = [
@@ -290,18 +290,18 @@ def model_to_vis_set(
 
                 if ff_attr.text:
                     units, tol = model.units, model.tolerance
-                    for f_attr in ff_attr.attr:
+                    for f_attr in ff_attr.attrs:
                         fa_col_obj = ColorFace(f_faces, f_attr, ff_attr.legend_par)
                         geo_objs.append(
                             color_face_to_vis_set(
                                 fa_col_obj, False, True, units, tol)[0]
                         )
                 if ff_attr.color:
-                    fa_col_obj = ColorFace(f_faces, ff_attr.attr[0], ff_attr.legend_par)
+                    fa_col_obj = ColorFace(f_faces, ff_attr.attrs[0], ff_attr.legend_par)
                     geo_obj = color_face_to_vis_set(fa_col_obj, False, False)[0]
                     geo_obj.identifier = clean_string(ff_attr.name)
                     geo_obj.display_name = ff_attr.name
-                    for r_attr in ff_attr.attr[1:]:
+                    for r_attr in ff_attr.attrs[1:]:
                         fa_col_obj = ColorFace(f_faces, r_attr, ff_attr.legend_par)
                         ra_a_geo = color_face_to_vis_set(fa_col_obj, False, False)[0]
                         geo_obj.add_data_set(ra_a_geo[0])

--- a/honeybee_display/model.py
+++ b/honeybee_display/model.py
@@ -11,6 +11,8 @@ from ladybug_display.visualization import VisualizationSet, ContextGeometry, \
     AnalysisGeometry, VisualizationData, VisualizationMetaData
 from honeybee.boundarycondition import Outdoors, Ground, Surface
 from honeybee.facetype import Wall, RoofCeiling, Floor, AirBoundary
+from honeybee.aperture import Aperture
+from honeybee.shade import Shade
 from honeybee.colorobj import ColorRoom, ColorFace
 
 from .colorobj import color_room_to_vis_set, color_face_to_vis_set
@@ -45,7 +47,8 @@ def model_to_vis_set(
         room_text_labels=False, face_text_labels=False,
         room_legend_par=None, face_legend_par=None,
         grid_display_mode='Default', hide_grid=True,
-        grid_data_path=None, grid_data_display_mode='Surface', active_grid_data=None):
+        grid_data_path=None, grid_data_display_mode='Surface', active_grid_data=None,
+        face_attr_types=None):
     """Translate a Honeybee Model to a VisualizationSet.
 
     Args:
@@ -141,6 +144,16 @@ def model_to_vis_set(
             AnalysisGeometry. This should match the name of the sub-folder
             within the grid_data_path that should be active. If None, the
             first data set in the grid_data_path with be active. (Default: None).
+        face_attr_types: List of face types to be included in the visualization set. By
+            default all the faces will be exported to visualization set when face_attr
+            is set. Valid values are:
+
+            * Wall
+            * RoofCeiling
+            * Floor
+            * AirBoundary
+            * Aperture
+            * Shade
 
     Returns:
         A VisualizationSet object that represents the model.
@@ -285,11 +298,21 @@ def model_to_vis_set(
         faces = []
         for room in model.rooms:
             faces.extend(room.faces)
+            faces.extend(room.apertures)
             faces.extend(room.shades)
         faces.extend(model.orphaned_faces)
         faces.extend(model.orphaned_apertures)
         faces.extend(model.orphaned_doors)
         faces.extend(model.orphaned_shades)
+
+        if face_attr_types:
+            face_attr_types = tuple(face_attr_types)
+            faces = [
+                face for face in faces
+                if isinstance(face, face_attr_types) or
+                isinstance(face.type, face_attr_types)
+            ]
+
         if len(faces) != 0:
             if face_text_labels:
                 units, tol = model.units, model.tolerance

--- a/honeybee_display/model.py
+++ b/honeybee_display/model.py
@@ -13,6 +13,7 @@ from honeybee.boundarycondition import Outdoors, Ground, Surface
 from honeybee.facetype import Wall, RoofCeiling, Floor, AirBoundary
 from honeybee.colorobj import ColorRoom, ColorFace
 from honeybee.shade import Shade
+from honeybee.typing import clean_string
 
 from .colorobj import color_room_to_vis_set, color_face_to_vis_set
 
@@ -246,8 +247,7 @@ def model_to_vis_set(
                 ra_col_obj = ColorRoom(model.rooms, attrs[0], rm_attr.legend_par)
                 geo_obj = color_room_to_vis_set(ra_col_obj, False, False)[0]
                 geo_obj.display_name = rm_attr.name
-                # TODO: pass the display name to the function that validates it
-                geo_obj.identifier = rm_attr.name
+                geo_obj.identifier = clean_string(rm_attr.name)
                 for r_attr in attrs[1:]:
                     ra_col_obj = ColorRoom(model.rooms, r_attr, rm_attr.legend_par)
                     ra_a_geo = color_room_to_vis_set(ra_col_obj, False, False)[0]
@@ -299,8 +299,7 @@ def model_to_vis_set(
                 if ff_attr.color:
                     fa_col_obj = ColorFace(f_faces, ff_attr.attr[0], ff_attr.legend_par)
                     geo_obj = color_face_to_vis_set(fa_col_obj, False, False)[0]
-                    # TODO: pass the display name through a validator
-                    geo_obj.identifier = ff_attr.name
+                    geo_obj.identifier = clean_string(ff_attr.name)
                     geo_obj.display_name = ff_attr.name
                     for r_attr in ff_attr.attr[1:]:
                         fa_col_obj = ColorFace(f_faces, r_attr, ff_attr.legend_par)

--- a/honeybee_display/model.py
+++ b/honeybee_display/model.py
@@ -11,12 +11,10 @@ from ladybug_display.visualization import VisualizationSet, ContextGeometry, \
     AnalysisGeometry, VisualizationData, VisualizationMetaData
 from honeybee.boundarycondition import Outdoors, Ground, Surface
 from honeybee.facetype import Wall, RoofCeiling, Floor, AirBoundary
-from honeybee.aperture import Aperture
-from honeybee.shade import Shade
 from honeybee.colorobj import ColorRoom, ColorFace
+from honeybee.shade import Shade
 
 from .colorobj import color_room_to_vis_set, color_face_to_vis_set
-from .attr import FaceAttribute, RoomAttribute
 
 TYPE_COLORS = {
     'Wall': Color(230, 180, 60),
@@ -269,7 +267,6 @@ def model_to_vis_set(
         faces.extend(model.orphaned_shades)
         if len(faces) != 0:
             for ff_attr in face_attr:
-                ff_attr: FaceAttribute
                 if ff_attr.face_types:
                     face_attr_types = tuple(ff_attr.face_types)
                     f_faces = [
@@ -279,6 +276,17 @@ def model_to_vis_set(
                     ]
                 else:
                     f_faces = faces
+
+                if ff_attr.boundary_conditions:
+                    bcs = tuple(ff_attr.boundary_conditions)
+                    f_faces = [
+                        face for face in f_faces if
+                        isinstance(face, Shade) or
+                        isinstance(face.boundary_condition, bcs)
+                    ]
+
+                if not f_faces:
+                    continue
 
                 if ff_attr.text:
                     units, tol = model.units, model.tolerance

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 ladybug-display>=0.7.1
-honeybee-core>=1.54.10
+honeybee-core>=1.56.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ladybug-display>=0.7.1
+ladybug-display>=0.7.2
 honeybee-core>=1.56.18

--- a/tests/model_extend_test.py
+++ b/tests/model_extend_test.py
@@ -53,15 +53,15 @@ def test_room_attr_to_vis_set():
     model_json = './tests/json/single_family_home.hbjson'
     parsed_model = Model.from_hbjson(model_json)
     attr_color = RoomAttribute(
-        name='Floor Area', attr=['floor_area'], text=False, color=True)
-    vis_set = parsed_model.to_vis_set('none', room_attr=[attr_color])
+        name='Floor Area', attrs=['floor_area'], text=False, color=True)
+    vis_set = parsed_model.to_vis_set('none', room_attrs=[attr_color])
 
     assert isinstance(vis_set[0], AnalysisGeometry)
     assert isinstance(vis_set[0][0], VisualizationData)
     assert len(vis_set[0][0].values) == 7
     attr_txt = RoomAttribute(
-        name='Floor Area', attr=['floor_area'], text=True, color=False)
-    vis_set = parsed_model.to_vis_set('none', room_attr=[attr_txt])
+        name='Floor Area', attrs=['floor_area'], text=True, color=False)
+    vis_set = parsed_model.to_vis_set('none', room_attrs=[attr_txt])
     assert isinstance(vis_set[0], ContextGeometry)
     assert len(vis_set[0]) == 7
     for item in vis_set[0]:
@@ -72,14 +72,14 @@ def test_face_attr_to_vis_set():
     """Test the face attribute argument of Model.to_vis_set()."""
     model_json = './tests/json/single_family_home.hbjson'
     parsed_model = Model.from_hbjson(model_json)
-    attr_color = FaceAttribute(name='Area', attr=['area'], color=True, text=False)
-    vis_set = parsed_model.to_vis_set('None', face_attr=[attr_color])
+    attr_color = FaceAttribute(name='Area', attrs=['area'], color=True, text=False)
+    vis_set = parsed_model.to_vis_set('None', face_attrs=[attr_color])
     assert isinstance(vis_set[0], AnalysisGeometry)
     assert isinstance(vis_set[0][0], VisualizationData)
     assert len(vis_set[0][0].values) == 140
 
-    attr_txt = FaceAttribute(name='Area', attr=['area'], color=False, text=True)
-    vis_set = parsed_model.to_vis_set('None', face_attr=[attr_txt])
+    attr_txt = FaceAttribute(name='Area', attrs=['area'], color=False, text=True)
+    vis_set = parsed_model.to_vis_set('None', face_attrs=[attr_txt])
     assert isinstance(vis_set[0], ContextGeometry)
     assert len(vis_set[0]) == 140
     for item in vis_set[0]:

--- a/tests/model_extend_test.py
+++ b/tests/model_extend_test.py
@@ -4,6 +4,7 @@ from ladybug_display.geometry3d import DisplayMesh3D, DisplayLineSegment3D, \
 from ladybug_display.visualization import VisualizationSet, \
     ContextGeometry, AnalysisGeometry, VisualizationData
 from honeybee.model import Model
+from honeybee_display.attr import RoomAttribute, FaceAttribute
 
 
 def test_default_to_vis_set():
@@ -34,7 +35,7 @@ def test_default_to_vis_set():
         assert isinstance(geo_obj[0], DisplayLineSegment3D)
 
     vis_set = parsed_model.to_vis_set('boundary_condition', include_wireframe=False)
-    print(len(vis_set))
+
     assert len(vis_set) == 4
     for geo_obj in vis_set:
         assert isinstance(geo_obj, ContextGeometry)
@@ -51,14 +52,16 @@ def test_room_attr_to_vis_set():
     """Test the room attribute argument of Model.to_vis_set()."""
     model_json = './tests/json/single_family_home.hbjson'
     parsed_model = Model.from_hbjson(model_json)
-    vis_set = parsed_model.to_vis_set('none', room_attr='floor_area')
+    attr_color = RoomAttribute(
+        name='Floor Area', attr=['floor_area'], text=False, color=True)
+    vis_set = parsed_model.to_vis_set('none', room_attr=[attr_color])
 
     assert isinstance(vis_set[0], AnalysisGeometry)
     assert isinstance(vis_set[0][0], VisualizationData)
     assert len(vis_set[0][0].values) == 7
-
-    vis_set = parsed_model.to_vis_set(
-        'none', room_attr='floor_area', room_text_labels=True)
+    attr_txt = RoomAttribute(
+        name='Floor Area', attr=['floor_area'], text=True, color=False)
+    vis_set = parsed_model.to_vis_set('none', room_attr=[attr_txt])
     assert isinstance(vis_set[0], ContextGeometry)
     assert len(vis_set[0]) == 7
     for item in vis_set[0]:
@@ -69,15 +72,15 @@ def test_face_attr_to_vis_set():
     """Test the face attribute argument of Model.to_vis_set()."""
     model_json = './tests/json/single_family_home.hbjson'
     parsed_model = Model.from_hbjson(model_json)
-    vis_set = parsed_model.to_vis_set('none', face_attr='area')
-
+    attr_color = FaceAttribute(name='Area', attr=['area'], color=True, text=False)
+    vis_set = parsed_model.to_vis_set('None', face_attr=[attr_color])
     assert isinstance(vis_set[0], AnalysisGeometry)
     assert isinstance(vis_set[0][0], VisualizationData)
-    assert len(vis_set[0][0].values) == 100
+    assert len(vis_set[0][0].values) == 140
 
-    vis_set = parsed_model.to_vis_set(
-        'none', face_attr='area', face_text_labels=True)
+    attr_txt = FaceAttribute(name='Area', attr=['area'], color=False, text=True)
+    vis_set = parsed_model.to_vis_set('None', face_attr=[attr_txt])
     assert isinstance(vis_set[0], ContextGeometry)
-    assert len(vis_set[0]) == 100
+    assert len(vis_set[0]) == 140
     for item in vis_set[0]:
         assert isinstance(item, DisplayText3D)


### PR DESCRIPTION
This PR introduces new objects for face and room attributes to allow mixing different combinations between different attributes.

This is a BREAKING CHANGE as it changes the input arguments for the function. I didn't try to fix the tests at this point because I wanted to make sure that @chriswmackey is fine with introducing these changes first.

Here is an example where I create two face attributes objects. The first face attribute colors the faces based on the `user_data.tag` and the other one writes the layer name using `user_data.__layer__`.

```python
from honeybee.model import Model, Aperture
from honeybee_display.model import model_to_vis_set, FaceAttribute, RoomAttribute
from ladybug_display.visualization import VisualizationSet
from ladybug_vtk.visualization_set import VisualizationSet as VTKVS

fp = r"classroom_tagged_aperture.hbjson"
model = Model.from_hbjson(fp)

fa_1 = FaceAttribute(
    name='Aperture_Tags',
    attr=['user_data.tag'], color=True,
    face_types=[Aperture]
)

fa_2 = FaceAttribute(
    name='Aperture_Layers',
    attr=['user_data.__layer__'], color=False, text=True,
    face_types=[Aperture]
)

vs: VisualizationSet = model_to_vis_set(model=model, face_attr=[fa_1, fa_2])

vvs = VTKVS.from_visualization_set(vs)
vvs.to_html(name='glass_model')
```
Here are the input and output files.

[test_files.zip](https://github.com/ladybug-tools/honeybee-display/files/12254989/test_files.zip)

The new attributes also allow filtering the objects by type. For this example, I'm only interested in the apertures.

![image](https://github.com/ladybug-tools/honeybee-display/assets/2915573/bf430c83-59ef-42c6-a888-63f9ab216151)


